### PR TITLE
refactor: Use DB To Save Entity

### DIFF
--- a/src/main/java/com/sy/domain/Note.java
+++ b/src/main/java/com/sy/domain/Note.java
@@ -5,13 +5,13 @@ import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import lombok.Builder;
 import lombok.Getter;
-import lombok.Setter;
 
 @Entity
 /* TODO: DB 구현 후 삭제 */
 @Getter
-@Setter
+@Builder
 public class Note {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/com/sy/domain/NoteRepository.java
+++ b/src/main/java/com/sy/domain/NoteRepository.java
@@ -1,0 +1,7 @@
+package com.sy.domain;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface NoteRepository extends JpaRepository<Note, Long> {
+    
+}

--- a/src/main/java/com/sy/service/BookServiceImpl.java
+++ b/src/main/java/com/sy/service/BookServiceImpl.java
@@ -7,11 +7,17 @@ import org.springframework.stereotype.Service;
 
 import com.sy.domain.Book;
 import com.sy.domain.Note;
+import com.sy.domain.NoteRepository;
 import com.sy.dto.BookNoteDetailRequest;
 import com.sy.dto.BookNoteDetailResponse;
 
+import lombok.RequiredArgsConstructor;
+
 @Service
+@RequiredArgsConstructor
 public class BookServiceImpl implements BookService {
+
+    private final NoteRepository noteRepository;
     
     @Override
     public Book findBookById(Long id) {
@@ -31,13 +37,9 @@ public class BookServiceImpl implements BookService {
 
     @Override
     public Note findNoteById(Long id) {
-        // TODO: setter 삭제 후 DB 조회 구현
     
-        Note note = new Note();
-
-        note.setId(id);
-        note.setContent("독서 기록 내용");
-        note.setCreatedDate("2025-01-01");
+        Note note = noteRepository.findById(id)
+            .orElseThrow(() -> new RuntimeException("Note not found"));
 
         return note;
     }
@@ -94,12 +96,15 @@ public class BookServiceImpl implements BookService {
 
     @Override
     public void createNote(BookNoteDetailRequest request) {
-        // TODO: DB 저장 구현 후 삭제
-        System.out.println("new note created!");
-        System.out.println(request.getTitle());
-        System.out.println(request.getAuthor());
-        System.out.println(request.getPublisher());
-        System.out.println(request.getContent());
+        // TODO: transactional 적용
+
+        Note note = Note.builder()
+            .title(request.getTitle())
+            .content(request.getContent())
+            .createdDate(request.getCreatedDate())
+            .build();
+        
+        noteRepository.save(note);
     }
 
 } 


### PR DESCRIPTION
기존 코드
- 아직 DB 연결이 없어서 Controller의 Post요청으로 받은 Request DTO를 엔티티의 Setter를 사용해 엔티티에 매핑하고, 엔티티가 잘 저장되었는지 콘솔 출력으로 확인

변경된 코드
- DB를 연결한 후 Controller의 Post요청으로 받은 Request DTO를 엔티티의 Builder 패턴을 사용해 엔티티에 매핑하고, 매핑된 엔티티를 Spring JPA Repository 메서드를 통해 DB에 저장함. 쿼리문이 자동으로 생성되는 것을 콘솔 출력으로 볼 수 있고, DB 서버에 접속하여 select문을 통해 실제로 엔티티가 테이블에 저장된 것을 확인할 수 있음.

[실습]
1. Postman으로 json데이터 post요청 보내기
![image](https://github.com/user-attachments/assets/7d9595ec-7bfb-4f0d-85fe-db2cc90e3901)

2. 컨트롤러에서 Post요청을 받고 서비스로 보냄
```
    @PostMapping("/book/{id}")
    public void createNote(@RequestBody BookNoteDetailRequest request) {
        bookService.createNote(request);
    }
```
3. 서비스에서 받은 요청을 빌더패턴을 적용하여 엔티티에 매핑 후 레포지토리 함수 호출
- Note 엔티티에 Setter을 빼고 빌더패턴을 적용함
```
    @Override
    public void createNote(BookNoteDetailRequest request) {
        // TODO: transactional 적용

        Note note = Note.builder()
            .title(request.getTitle())
            .content(request.getContent())
            .createdDate(request.getCreatedDate())
            .build();
        
        noteRepository.save(note);
    }
```
4. 레포지토리는 JpaRepository를 상속하고 있으므로 CRUD 함수가 기본적으로 제공됨
- save()를 호출하였으므로 note 객체를 테이블에 저장하는 쿼리문이 자동 호출됨
```
public interface NoteRepository extends JpaRepository<Note, Long> {
    
}
```
5. yml파일에 설정해둔 쿼리문 출력 설정으로 인해 호출된 쿼리문이 콘솔에 출력되는 것을 확인할 수 있음
![image](https://github.com/user-attachments/assets/b6fed8c4-c2db-4e84-bc77-b96911fc48b8)
6. mariadb 서버에 접속하여 select문으로 조회해보기
- mysql -u root -p
- show databases
- use [db이름]
- show tables
- select * from [table이름]
![image](https://github.com/user-attachments/assets/31ca1be5-68fd-4d6c-91be-f2868d757c4e)



