### PR TITLE
Note가 없는 Book이 조회되도록 수정, 순환참조 제거

### DIFF
--- a/src/main/java/com/sy/controller/PageController.java
+++ b/src/main/java/com/sy/controller/PageController.java
@@ -9,8 +9,8 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RestController;
 
-import com.sy.domain.Book;
 import com.sy.dto.BookNoteDetailResponse;
+import com.sy.dto.BookResponse;
 import com.sy.dto.CreateNoteRequest;
 import com.sy.service.BookService;
 
@@ -23,7 +23,7 @@ public class PageController {
     private final BookService bookService;
     
     @GetMapping("/booklist")
-    public List<Book> getBookList() {
+    public List<BookResponse> getBookList() {
         return bookService.getBookList();
     }
 

--- a/src/main/java/com/sy/dto/BookResponse.java
+++ b/src/main/java/com/sy/dto/BookResponse.java
@@ -1,0 +1,17 @@
+package com.sy.dto;
+
+import java.util.List;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class BookResponse {
+    private Long id;
+    private String title;
+    private String author;
+    private String publisher;
+    private String coverImage;
+    private String description;
+    private List<NoteResponse> notes;
+} 

--- a/src/main/java/com/sy/dto/NoteResponse.java
+++ b/src/main/java/com/sy/dto/NoteResponse.java
@@ -1,0 +1,14 @@
+package com.sy.dto;
+
+import java.time.LocalDateTime;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class NoteResponse {
+    private Long id;
+    private String title;
+    private String content;
+    private LocalDateTime createdDate;
+} 

--- a/src/main/java/com/sy/service/BookService.java
+++ b/src/main/java/com/sy/service/BookService.java
@@ -6,12 +6,13 @@ import com.sy.domain.Book;
 import com.sy.domain.Note;
 import com.sy.dto.BookNoteDetailResponse;
 import com.sy.dto.CreateNoteRequest;
+import com.sy.dto.BookResponse;
 
 public interface BookService {
     Book findBookById(Long id);
     Note findNoteById(Long id);
     BookNoteDetailResponse getBookNoteDetail(Long id);
-    List<Book> getBookList();
+    List<BookResponse> getBookList();
     void createNote(Long id, CreateNoteRequest request);
     void deleteNote(Long bookId, Long noteId);
 } 

--- a/src/main/java/com/sy/service/BookServiceImpl.java
+++ b/src/main/java/com/sy/service/BookServiceImpl.java
@@ -11,6 +11,8 @@ import com.sy.domain.Note;
 import com.sy.domain.NoteRepository;
 import com.sy.dto.BookNoteDetailResponse;
 import com.sy.dto.CreateNoteRequest;
+import com.sy.dto.BookResponse;
+import com.sy.dto.NoteResponse;
 
 import lombok.RequiredArgsConstructor;
 
@@ -71,8 +73,26 @@ public class BookServiceImpl implements BookService {
     }
 
     @Override
-    public List<Book> getBookList() {
-        return bookRepository.findAll();
+    public List<BookResponse> getBookList() {
+        List<Book> books = bookRepository.findAll();
+        return books.stream().map(book ->
+            BookResponse.builder()
+                .id(book.getId())
+                .title(book.getTitle())
+                .author(book.getAuthor())
+                .publisher(book.getPublisher())
+                .coverImage(book.getCoverImage())
+                .description(book.getDescription())
+                .notes(book.getNotes().stream().map(note ->
+                    NoteResponse.builder()
+                        .id(note.getId())
+                        .title(note.getTitle())
+                        .content(note.getContent())
+                        .createdDate(note.getCreatedDate())
+                        .build()
+                ).toList())
+                .build()
+        ).toList();
     }
 
     @Override

--- a/src/main/java/com/sy/service/BookServiceImpl.java
+++ b/src/main/java/com/sy/service/BookServiceImpl.java
@@ -24,14 +24,14 @@ public class BookServiceImpl implements BookService {
     @Override
     public Book findBookById(Long id) {
         return bookRepository.findById(id)
-            .orElseThrow(() -> new RuntimeException("Book not found"));
+            .orElseThrow(() -> new RuntimeException("책을 찾을 수 없습니다."));
     }
 
     @Override
     public Note findNoteById(Long id) {
     
         Note note = noteRepository.findById(id)
-            .orElseThrow(() -> new RuntimeException("Note not found"));
+            .orElseThrow(() -> new RuntimeException("노트를 찾을 수 없습니다."));
 
         return note;
     }
@@ -39,19 +39,35 @@ public class BookServiceImpl implements BookService {
     @Override
     public BookNoteDetailResponse getBookNoteDetail(Long id) {
         
-        Book book = findBookById(id);
-        
-        return BookNoteDetailResponse.builder()
-                .bookId(book.getId())
-                .title(book.getTitle())
-                .author(book.getAuthor())
-                .publisher(book.getPublisher())
-                .coverImage(book.getCoverImage())
-                .description(book.getDescription())
-                .noteId(book.getNotes().get(0).getId())
-                .content(book.getNotes().get(0).getContent())
-                .createdDate(book.getNotes().get(0).getCreatedDate())
+        try{
+            Book foundBook = findBookById(id);
+            
+            if(foundBook.getNotes().isEmpty()) {
+                return BookNoteDetailResponse.builder()
+                .bookId(foundBook.getId())
+                .title(foundBook.getTitle())
+                .author(foundBook.getAuthor())
+                .publisher(foundBook.getPublisher())
+                .coverImage(foundBook.getCoverImage())
+                .description(foundBook.getDescription())
                 .build();
+            }else {
+                return BookNoteDetailResponse.builder()
+                        .bookId(foundBook.getId())
+                        .title(foundBook.getTitle())
+                        .author(foundBook.getAuthor())
+                        .publisher(foundBook.getPublisher())
+                        .coverImage(foundBook.getCoverImage())
+                        .description(foundBook.getDescription())
+                        .noteId(foundBook.getNotes().get(0).getId())
+                        .content(foundBook.getNotes().get(0).getContent())
+                        .createdDate(foundBook.getNotes().get(0).getCreatedDate())
+                        .build();
+            }
+        } catch (Exception e) {
+            throw new RuntimeException("책을 찾을 수 없습니다.");
+        }
+        
     }
 
     @Override


### PR DESCRIPTION
### Note가 없는 Book이 조회되도록 수정
Book에 해당하는 Note가 없으면 BookNoteDetailResponse dto 내부의 Note 필드를 null로 채우게 하는 조건문 추가
### 순환 참조 제거
[문제]
Book List를 조회하는 로직에서 Book 엔티티 자체를 조회한 결과를 응답값으로 전송하니 다음과 같이 순환 참조된 데이터가 넘어감
```
@Entity
public class Book {
    @OneToMany(mappedBy = "book")
    private List<Note> notes;
}
```
```
@Entity
public class Note {
    @ManyToOne
    private Book book;
}
```
Jackson이 직렬화(JSON 변환) 할 때 Book → Note → Book → Note → … 식으로 무한 루프에 빠짐
API 응답에서 StackOverflowError 발생

[해결] 
Note 엔티티의 Book 필드에 @JsonIgnore을 추가하면 Note를 직렬화할 때 book필드를 무시함으로써 해결 가능하나, Note를 직렬화할 때 book 정보가 필요하다면 주의해야 하는 방법이므로 엔티티를 직접 반환하지 않고 필요한 정보만 담은 DTO로 변환해서 반환하는 방법으로 변경. 유지보수/확장에도 좋은 방법임
![image](https://github.com/user-attachments/assets/81ce6f6a-dd4e-424e-86a3-35f76180a145)
