### PR TITLE
Note 생성 시 작성자 정보 추가

### DIFF
--- a/src/main/java/com/sy/controller/PageController.java
+++ b/src/main/java/com/sy/controller/PageController.java
@@ -7,11 +7,13 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.sy.dto.BookNoteDetailResponse;
 import com.sy.dto.BookResponse;
 import com.sy.dto.CreateNoteRequest;
+import com.sy.jwt.JwtUtil;
 import com.sy.service.BookService;
 
 import lombok.RequiredArgsConstructor;
@@ -21,6 +23,7 @@ import lombok.RequiredArgsConstructor;
 public class PageController {
 
     private final BookService bookService;
+    private final JwtUtil jwtUtil;
     
     @GetMapping("/booklist")
     public List<BookResponse> getBookList() {
@@ -32,9 +35,14 @@ public class PageController {
         return bookService.getBookNoteDetail(id);
     }
 
-    @PostMapping("/book/{id}")
-    public void createNote(@PathVariable Long id, @RequestBody CreateNoteRequest request) {
-        bookService.createNote(id, request);
+    @PostMapping("/book/{bookId}")
+    public void createNote(
+        @PathVariable Long bookId, 
+        @RequestBody CreateNoteRequest request,
+        @RequestHeader("Authorization") String authHeader) {
+        String token = authHeader.substring(7); //"Bearer " 제거
+        String writer = jwtUtil.getNameFromToken(token);
+        bookService.createNote(bookId, request, writer);
     }
 
     @DeleteMapping("/book/{bookId}/{noteId}")

--- a/src/main/java/com/sy/domain/Note.java
+++ b/src/main/java/com/sy/domain/Note.java
@@ -30,6 +30,9 @@ public class Note {
     @Column(name = "content")
     private String content;
 
+    @Column(name = "writer")
+    private String writer;
+
     @Column(name = "created_date")
     private LocalDateTime createdDate;
 
@@ -38,9 +41,10 @@ public class Note {
     private Book book;
 
     @Builder
-    public Note(String title, String content, Book book) {
+    public Note(String title, String content, Book book, String writer) {
         this.title = title;
         this.content = content;
+        this.writer = writer;
         this.book = book;
         this.createdDate = LocalDateTime.now();
     }

--- a/src/main/java/com/sy/dto/CreateNoteRequest.java
+++ b/src/main/java/com/sy/dto/CreateNoteRequest.java
@@ -8,4 +8,5 @@ public class CreateNoteRequest {
     private Long noteId;
     private String title;
     private String content;
+    private String writer;
 }

--- a/src/main/java/com/sy/jwt/JwtUtil.java
+++ b/src/main/java/com/sy/jwt/JwtUtil.java
@@ -21,9 +21,10 @@ public class JwtUtil {
     }
 
     /* JWT 토큰 생성 (로그인 성공 시) */
-    public String generateToken(String email) {
+    public String generateToken(String email, String name) {
         return Jwts.builder()
                 .setSubject(email) //토큰 주제(이메일)
+                .claim("name", name)
                 .setIssuedAt(new Date()) //토큰 발급 시간
                 .setExpiration(new Date(System.currentTimeMillis() + EXPIRATION)) //토큰 만료 시간
                 .signWith(getSigningKey(), SignatureAlgorithm.HS256) //토큰 서명 알고리즘
@@ -38,6 +39,16 @@ public class JwtUtil {
                 .parseClaimsJws(token) //토큰 파싱 및 검증
                 .getBody()
                 .getSubject(); //토큰 주제(이메일) 반환
+    }
+
+    /* 토큰에서 이름 추출 */
+    public String getNameFromToken(String token) {
+        return Jwts.parserBuilder()
+                .setSigningKey(getSigningKey())
+                .build()
+                .parseClaimsJws(token)
+                .getBody()
+                .get("name", String.class);
     }
 
     /* 토큰 유효성 검증 */

--- a/src/main/java/com/sy/service/BookService.java
+++ b/src/main/java/com/sy/service/BookService.java
@@ -13,6 +13,6 @@ public interface BookService {
     Note findNoteById(Long id);
     BookNoteDetailResponse getBookNoteDetail(Long id);
     List<BookResponse> getBookList();
-    void createNote(Long id, CreateNoteRequest request);
+    void createNote(Long bookId, CreateNoteRequest request, String writer);
     void deleteNote(Long bookId, Long noteId);
 } 

--- a/src/main/java/com/sy/service/BookServiceImpl.java
+++ b/src/main/java/com/sy/service/BookServiceImpl.java
@@ -97,13 +97,14 @@ public class BookServiceImpl implements BookService {
 
     @Override
     @Transactional
-    public void createNote(Long bookId, CreateNoteRequest request) {
+    public void createNote(Long bookId, CreateNoteRequest request, String writer) {
         Book foundBook = bookRepository.findById(bookId) 
             .orElseThrow(() -> new RuntimeException("책을 찾을 수 없습니다."));
         
         Note note = Note.builder()
             .title(request.getTitle())
             .content(request.getContent())
+            .writer(writer)
             .book(foundBook)
             .build();
         

--- a/src/main/java/com/sy/service/UserService.java
+++ b/src/main/java/com/sy/service/UserService.java
@@ -34,7 +34,7 @@ public class UserService {
         if (!passwordEncoder.matches(request.getPassword(), user.getPassword())) {
             throw new RuntimeException("이메일 또는 비밀번호가 올바르지 않습니다.");
         }
-        // JWT 토큰 발급
-        return jwtUtil.generateToken(user.getEmail());
+        // JWT 토큰 발급 (이메일, 이름 포함)
+        return jwtUtil.generateToken(user.getEmail(), user.getName());
     }
 }


### PR DESCRIPTION
### Note 작성자도 같이 저장되도록 수정!!
처음에는 jwt token의 subject로 지정한 email을 사용해서 findByEmail()로 db를 조회하여 로그인 사용자의 이름을 조회하려 했으나, db 검색에 의한 성능 저하를 고려하여 토큰에 로그인 사용자 이름 정보를 같이 저장하기로 했음. 이렇게 자주 사용되는 정보는 토큰에서 바로 꺼내쓸 수 있도록 토큰에 저장해둔다고 함

1. jwt 토큰에 로그인 사용자 이름을 추가 

2. 컨트롤러에서 @RequestHeader("Authorization")으로 토큰 파싱해서 가져오기

3. 토큰 앞에 "Bearer "을 substring으로 제거

4. jwtUtil.getNameFromToken()으로 토큰에 저장해둔 로그인 사용자 이름을 추출

5. service 로직으로 사용자 이름을 넘김
